### PR TITLE
refactor: suggested changed

### DIFF
--- a/src/MerakiToken.sol
+++ b/src/MerakiToken.sol
@@ -57,7 +57,7 @@ contract MerakiToken is ERC721, Ownable {
     /**
      * @notice all tokens share the same meta data so tokenId is not used
      */
-    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+    function tokenURI(uint256) public view override returns (string memory) {
         return uri;
     }
 

--- a/src/Olympus.sol
+++ b/src/Olympus.sol
@@ -130,7 +130,7 @@ contract Olympus is RewardDistributor, ERC721Holder {
 
         //send user their NFTs
         uint256 idToTransfer;
-        for (uint256 i = 1; i <= _amount; i++) {
+        for (uint256 i; i < _amount; i++) {
             idToTransfer = userNFTIds[msg.sender].at(0);
             userNFTIds[msg.sender].remove(idToTransfer);
             MerakiToken.safeTransferFrom(address(this), msg.sender, idToTransfer);
@@ -150,8 +150,9 @@ contract Olympus is RewardDistributor, ERC721Holder {
      * @notice get an array of token ids a user has in Olympus
      */
     function usersNFTs(address _user) public view returns (uint256[] memory ids) {
-        ids = new uint256[](userNFTIds[_user].length());
-        for (uint256 i = 0; i < userNFTIds[_user].length(); i++) {
+        uint256 numOfNFTs = userNFTIds[_user].length();
+        ids = new uint256[](numOfNFTs);
+        for (uint256 i = 0; i < numOfNFTs; i++) {
             ids[i] = userNFTIds[_user].at(i);
         }
         return ids;


### PR DESCRIPTION
Besides the refactors implemented [here](https://github.com/crispymangoes/meraki-olympus/pull/1/files), below are addition comments/questions/suggestions organized by contract. Also note that some of these refactors may be redundant or irrelevant if you decide to merge [this rewrite](https://github.com/crispymangoes/meraki-olympus/pull/2).

## Olympus
- Why is `totalAmountDeposited()` needed? It's just an alias for `totalDeposits`.

## RewardDistributor
- If `userBalance()` is suppose to be implemented in `Olympus`, leave it as just a function signature with no implementation.  `RewardDistributor` is already an abstract anyway so this makes more sense. It's confusing and a potential footgun to reviewers/you to have the implementation change in the inheriting contract if they aren't paying attention. You can make it more clear that it is changed by just leaving it without an implementation in `RewardDistributor`.

## OlympusAggregator
- The `withdrawToken()` function is pretty scary for users and casual readers of your code. Even though we know `OlympusAggregator` shouldn't have that big of a balance if `upkeepMinimum` is reasonably set, others might not.  Consider limiting it to only `token != rewardToken`, assuming it's not suppose to be able to withdraw *any* token and just tokens that aren't meant to be there, and renaming it `sweep()` to indicate it is only meant to be used to sweep out tokens that are not the reward token.